### PR TITLE
[CORRETTO-1] Move to uberjar packaging

### DIFF
--- a/bin/corretto-submit
+++ b/bin/corretto-submit
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Licensed to Big Data Genomics (BDG) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The BDG licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# usage: corretto-submit [<spark-args> --] <corretto-args>
+
+set -e
+
+# Split args into Spark and corretto args
+DD=False  # DD is "double dash"
+PRE_DD=()
+POST_DD=()
+for ARG in "$@"; do
+  shift
+  if [[ $ARG == "--" ]]; then
+    DD=True
+    POST_DD=( "$@" )
+    break
+  fi
+  PRE_DD+=("$ARG")
+done
+
+if [[ $DD == True ]]; then
+  SPARK_ARGS="${PRE_DD[@]}"
+  CORRETTO_ARGS="${POST_DD[@]}"
+else
+  SPARK_ARGS=()
+  CORRETTO_ARGS="${PRE_DD[@]}"
+fi
+
+# Figure out where CORRETTO is installed
+SCRIPT_DIR="$(cd `dirname $0`/..; pwd)"
+
+# Find CORRETTO cli assembly jar
+CORRETTO_CLI_JAR=
+ASSEMBLY_DIR="$SCRIPT_DIR/target"
+
+num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^corretto.*[^javadoc]\.jar$" | wc -l)"
+if [ "$num_jars" -eq "0" ]; then
+  echo "Failed to find corretto jar in $ASSEMBLY_DIR." 1>&2
+  echo "You need to build corretto before running this program." 1>&2
+  exit 1
+fi
+ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^corretto.*[^javadoc]\.jar$" || true)"
+if [ "$num_jars" -gt "1" ]; then
+  echo "Found multiple corretto jars in $ASSEMBLY_DIR:" 1>&2
+  echo "$ASSEMBLY_JARS" 1>&2
+  echo "Please remove all but one jar." 1>&2
+  exit 1
+fi
+
+CORRETTO_CLI_JAR="${ASSEMBLY_DIR}/${ASSEMBLY_JARS}"
+
+# Find spark-submit script
+if [ -z "$SPARK_HOME" ]; then
+  SPARK_SUBMIT=$(which spark-submit)
+else
+  SPARK_SUBMIT="$SPARK_HOME"/bin/spark-submit
+fi
+if [ -z "$SPARK_SUBMIT" ]; then
+  echo "SPARK_HOME not set and spark-submit not on PATH; Aborting."
+  exit 1
+fi
+echo "Using SPARK_SUBMIT=$SPARK_SUBMIT"
+
+# submit the job to Spark
+"$SPARK_SUBMIT" \
+  --class org.bdgenomics.corretto.Corretto \
+  --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
+  --conf spark.kryo.registrator=org.bdgenomics.adam.serialization.ADAMKryoRegistrator \
+  $SPARK_ARGS \
+  $CORRETTO_CLI_JAR \
+  $CORRETTO_ARGS

--- a/pom.xml
+++ b/pom.xml
@@ -58,23 +58,33 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>appassembler-maven-plugin</artifactId>
-        <version>1.8</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.1</version>
         <configuration>
-          <programs>
-            <program>
-              <mainClass>org.bdgenomics.corretto.Corretto</mainClass>
-              <id>corretto</id>
-            </program>
-          </programs>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
         <executions>
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>assemble</goal>
+              <goal>shade</goal>
             </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Moves Corretto's packaging system to an uberjar, as we did recently in
ADAM. Also, I've added bin/corretto-submit, which allows users to run
Corretto from the command line. Resolves #1.
